### PR TITLE
Add VanishNoPacket to softdepend

### DIFF
--- a/plugin.yml
+++ b/plugin.yml
@@ -2,7 +2,7 @@ name: KoTH
 main: subside.plugins.koth.KothPlugin
 version: 1.4.8
 author: SubSide
-softdepend: [Multiverse-Core, Factions, Kingdoms, LegacyFactions, PlaceholderAPI]
+softdepend: [Multiverse-Core, Factions, Kingdoms, LegacyFactions, PlaceholderAPI, VanishNoPacket]
 commands:
   koth:
     description: Gives access to koth


### PR DESCRIPTION
The VanishHook in KoTH wasn't enabled when VanishNoPacket was enabled in the server after KoTH. This softdepend ensures that KoTH is enabled after VanishNoPacket, making the VanishHook work again.

Here is a screenshot of the bug: https://gyazo.com/09394108bab8970644d9d2b328a241c1
The vanish hook was set to true in the config.