### PR TITLE
Version 1.5.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ http://dev.thomasvdbulk.nl/KoTH/
 \- Factions  
 \- FactionsOne  
 \- FactionsUUID  
+\- Feudal Kingdoms  
 \- GangsPlus  
 \- Kingdoms  
 \- LegacyFactions (Special thanks to @MarkehMe for adding that)  
@@ -51,13 +52,12 @@ Although my plugin is completely modular in a way that dependencies aren't inter
 #### Java 1.8+
 To use the Java Lambda feature, Java 1.8 or higher is required.
 
-#### Spigot 1.9+ (and 1.7 (??))
+#### Spigot 1.9+
 Although you might not find this worthy to place here, I feel like I want to cover everything.  
   
 1.9+ is needed for BossBarAPI support. As mentioned above, I have a separate plugin that adds support to the **plugin** BossBarAPI, but I **also** support the integrated API by spigot in this plugin itself. Since this was introduced in 1.9 you need 1.9 or higher for this support.  
 I'm always trying to use the latest build, so I do recommend you doing that too.  
   
-1.7 is only used for the JSON beautifier, below is shown how you can easily remove this dependency if you want to.  
 
 #### Lombok
 _Tip: Lombok is the only required dependency that is not automatically imported by Maven!_  
@@ -95,6 +95,7 @@ Here is a list of all the current dependencies used in KoTH:
 \- Factions  
 \- FactionsUUID  
 \- Featherboard  
+\- Feudal Kingdoms  
 \- GangsPlus  
 \- GLib (As a dependency of Kingdoms)  
 \- Kingdoms  
@@ -104,8 +105,7 @@ Here is a list of all the current dependencies used in KoTH:
 \- McMMO  
 \- PlaceholderAPI (Through Maven)  
 \- PvPManager  
-\- Spigot 1.11.2 (Through maven)  
-\- Spigot 1.7  
+\- Spigot 1.12.2 (Through maven)  
 \- VanishNoPacket  
 \- Worldedit (Through maven)  
   

--- a/README.md
+++ b/README.md
@@ -110,13 +110,7 @@ Here is a list of all the current dependencies used in KoTH:
 \- Worldedit (Through maven)  
   
 _Small tip, whenever I re-import all jars, lots of times I have trouble with the CappingFactionsUUID. If this happens, remove the Factions dependency, wait for CappingFactionsUUID to stop showing errors, and then re-add it. Most of the time this fixes it._  
-  
-As you can see, Spigot 1.7 is not required, as you don't actually need it. By simply changing the `getGson(String str)` function in JSONLoader with the following code, you can completely remove 1.7 as a dependency:  
-```java
-private String getGson(String str){
-    return new com.google.gson.GsonBuilder().setPrettyPrinting().disableHtmlEscaping().create().toJson(new com.google.gson.JsonParser().parse(str));
-}
-```  
+   
   
 ### Current state of the code
 Don't be scared of the amount of code! After the refactorization of the beginning of 2017, the code has been a lot more cleaned up. If you want to change something with the code and you have something specific in mind, big chance it has been sorted for you and you can easily find it. Change something to the Gamemodes? It's in the gamemodes package. Commands? Commands package. Etc etc.  

--- a/config.yml
+++ b/config.yml
@@ -86,6 +86,7 @@ koth:
     every-x-seconds: 600
     decrease-by: 60
     minimum: 300
+  start-new-on-end: false # This is using the map-rotation!
   map-rotation:
     - "map1"
     - "map2"

--- a/config.yml
+++ b/config.yml
@@ -49,6 +49,7 @@ hooks:
   vanishnopacket: true
   factions: true
   kingdoms: true
+  feudalkingdoms: true
   gangs: true
   mcmmo: true
   pvpmanager: true

--- a/plugin.yml
+++ b/plugin.yml
@@ -23,6 +23,7 @@ permissions:
       koth.version: true
       koth.ignore: true
       koth.next: true
+      koth.top: true
   koth.help:
     description: Gives the player permissions to /koth (help)
     default: true
@@ -43,6 +44,9 @@ permissions:
     default: true
   koth.next:
     description: Gives the player permissions to /koth next
+    default: true
+  koth.top:
+    description: Gives the player permissions to /koth top
     default: true
 
   koth.admin:

--- a/plugin.yml
+++ b/plugin.yml
@@ -1,6 +1,6 @@
 name: KoTH
 main: subside.plugins.koth.KothPlugin
-version: 1.5.0
+version: 1.5.0b
 author: SubSide
 softdepend: [Multiverse-Core, Factions, Kingdoms, LegacyFactions, PlaceholderAPI, VanishNoPacket]
 commands:

--- a/plugin.yml
+++ b/plugin.yml
@@ -1,6 +1,6 @@
 name: KoTH
 main: subside.plugins.koth.KothPlugin
-version: 1.5.0b
+version: 1.5.1
 author: SubSide
 softdepend: [Multiverse-Core, Factions, Kingdoms, LegacyFactions, PlaceholderAPI, VanishNoPacket]
 commands:

--- a/pom.xml
+++ b/pom.xml
@@ -35,7 +35,7 @@
         <dependency>
             <groupId>org.spigotmc</groupId>
             <artifactId>spigot-api</artifactId>
-            <version>1.11-R0.1-SNAPSHOT</version>
+            <version>1.12.2-R0.1-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>com.sk89q</groupId>

--- a/src/subside/plugins/koth/KothPlugin.java
+++ b/src/subside/plugins/koth/KothPlugin.java
@@ -13,12 +13,7 @@ import subside.plugins.koth.events.KothPluginInitializationEvent;
 import subside.plugins.koth.gamemodes.GamemodeRegistry;
 import subside.plugins.koth.hooks.HookManager;
 import subside.plugins.koth.loot.LootHandler;
-import subside.plugins.koth.modules.AbstractModule;
-import subside.plugins.koth.modules.CacheHandler;
-import subside.plugins.koth.modules.ConfigHandler;
-import subside.plugins.koth.modules.EventListener;
-import subside.plugins.koth.modules.KothHandler;
-import subside.plugins.koth.modules.Lang;
+import subside.plugins.koth.modules.*;
 import subside.plugins.koth.scheduler.MapRotation;
 import subside.plugins.koth.scheduler.ScheduleHandler;
 import subside.plugins.koth.utils.MessageBuilder;
@@ -37,6 +32,7 @@ public class KothPlugin extends JavaPlugin {
     private @Getter MapRotation mapRotation;
 	private @Getter DataTable dataTable;
 	private @Getter CacheHandler cacheHandler;
+	private @Getter VersionChecker versionChecker;
 	
 	private List<AbstractModule> activeModules;
 	
@@ -95,6 +91,10 @@ public class KothPlugin extends JavaPlugin {
         // Add ScheduleHandler
         scheduleHandler = new ScheduleHandler(this);
         activeModules.add(scheduleHandler);
+
+        // Add VersionChecker
+		versionChecker = new VersionChecker(this);
+		activeModules.add(versionChecker);
         
         
         /* Now add all the dynamic modules */

--- a/src/subside/plugins/koth/captureentities/CappingFeudalKingdom.java
+++ b/src/subside/plugins/koth/captureentities/CappingFeudalKingdom.java
@@ -1,0 +1,58 @@
+package subside.plugins.koth.captureentities;
+
+import java.util.*;
+
+import org.bukkit.OfflinePlayer;
+import org.bukkit.entity.Player;
+import us.forseth11.feudal.core.Feudal;
+import us.forseth11.feudal.kingdoms.Kingdom;
+import us.forseth11.feudal.user.User;
+
+public class CappingFeudalKingdom extends CappingGroup<Kingdom> {
+
+    public CappingFeudalKingdom(CaptureTypeRegistry captureTypeRegistry, Kingdom kingdom){
+        super(captureTypeRegistry, "kingdom", kingdom);
+    }
+
+    public CappingFeudalKingdom(CaptureTypeRegistry captureTypeRegistry, Collection<Player> playerList){
+        this(captureTypeRegistry,
+                playerList.stream() // Create a stream
+                        .filter(player -> Feudal.getAPI().getKingdom(player) != null) // Filter to only players in a kingdom
+                        .map(player -> Feudal.getAPI().getKingdom(player)) // Create a new stream containing kingdoms
+                        .findAny() // Grab a single kingdom
+                        .orElse(null) // If no kingdom exists return null
+        );
+    }
+
+    public CappingFeudalKingdom(CaptureTypeRegistry captureTypeRegistry, String uuid){
+        this(captureTypeRegistry, Feudal.getAPI().getKingdomByUUID(uuid));
+    }
+
+    @Override
+    public boolean isInOrEqualTo(OfflinePlayer oPlayer){
+        return getObject().equals(Feudal.getAPI().getKingdom(oPlayer));
+    }
+
+    @Override
+    public String getUniqueObjectIdentifier(){
+        return getObject().getUUID();
+    }
+
+    @Override
+    public String getName(){
+        return getObject().getName();
+    }
+
+    @Override
+    public Collection<Player> getAllOnlinePlayers(){
+        List<Player> list = new ArrayList<>();
+        for(Map.Entry<String, User> member : Feudal.getOnlinePlayers().entrySet()){
+            if(!member.getValue().getKingdomUUID().equals(getObject().getUUID()))
+                continue;
+
+            list.add(member.getValue().getPlayer());
+        }
+
+        return list;
+    }
+}

--- a/src/subside/plugins/koth/captureentities/CaptureTypeRegistry.java
+++ b/src/subside/plugins/koth/captureentities/CaptureTypeRegistry.java
@@ -97,7 +97,7 @@ public class CaptureTypeRegistry extends AbstractModule {
         captureTypes.put(captureTypeIdentifier, clazz);
         
         // Automatically register the CappingGroup class if the registered class is from the CappingGroup type
-        if(CappingGroup.class.isInstance(clazz)){
+        if(CappingGroup.class.isAssignableFrom(clazz)){
             registerCaptureClass("groupclass", CappingGroup.class);
             
             // Since we know we have a group plugin, we can also register Conquest in the GamemodeRegistry

--- a/src/subside/plugins/koth/captureentities/CaptureTypeRegistry.java
+++ b/src/subside/plugins/koth/captureentities/CaptureTypeRegistry.java
@@ -9,9 +9,11 @@ import org.bukkit.entity.Player;
 
 import lombok.Getter;
 import lombok.Setter;
+import org.bukkit.plugin.PluginManager;
 import subside.plugins.koth.KothPlugin;
 import subside.plugins.koth.gamemodes.KothConquest;
 import subside.plugins.koth.modules.AbstractModule;
+import subside.plugins.koth.modules.ConfigHandler;
 
 @SuppressWarnings("rawtypes")
 public class CaptureTypeRegistry extends AbstractModule {
@@ -29,16 +31,19 @@ public class CaptureTypeRegistry extends AbstractModule {
     public void onLoad(){
         captureTypes.clear();
         captureClasses.clear();
+
+        PluginManager pluginManager = plugin.getServer().getPluginManager();
+        ConfigHandler.Hooks hooks = plugin.getConfigHandler().getHooks();
         
         // Add the player entity
         registerCaptureClass("capperclass", Capper.class);
         registerCaptureType("player", CappingPlayer.class, true);
         
         // LegacyFactions, Factions, and FactionsUUID
-        if(plugin.getConfigHandler().getHooks().isFactions()) {
-            if(plugin.getServer().getPluginManager().getPlugin("LegacyFactions") != null){
+        if(hooks.isFactions()) {
+            if(pluginManager.getPlugin("LegacyFactions") != null){
                 registerCaptureType("legacyfactions", CappingLegacyFactions.class, true);
-            } else if(plugin.getServer().getPluginManager().getPlugin("Factions") != null){
+            } else if(pluginManager.getPlugin("Factions") != null){
                 try {
                     // If this class is not found it means that Factions is not in the server
                     Class.forName("com.massivecraft.factions.entity.FactionColl");
@@ -53,17 +58,22 @@ public class CaptureTypeRegistry extends AbstractModule {
         }
         
         // Kingdoms
-        if(plugin.getConfigHandler().getHooks().isKingdoms() && plugin.getServer().getPluginManager().getPlugin("Kingdoms") != null){
+        if(hooks.isKingdoms() && pluginManager.getPlugin("Kingdoms") != null){
             registerCaptureType("kingdom", CappingKingdom.class, true);
+        }
+
+        // Feudal Kingdoms
+        if(hooks.isFeudalKingdoms() && pluginManager.getPlugin("Feudal") != null){
+            registerCaptureType("kingdom", CappingFeudalKingdom.class, true);
         }
         
         // Gangs
-        if(plugin.getConfigHandler().getHooks().isGangs() && plugin.getServer().getPluginManager().getPlugin("GangsPlus") != null){
+        if(hooks.isGangs() && pluginManager.getPlugin("GangsPlus") != null){
             registerCaptureType("gang", CappingGang.class, true);
         }
         
         // mcMMO parties
-        if(plugin.getConfigHandler().getHooks().isMcMMO() && plugin.getServer().getPluginManager().getPlugin("mcMMO") != null){
+        if(hooks.isMcMMO() && pluginManager.getPlugin("mcMMO") != null){
         	registerCaptureType("mcmmoparty", CappingMCMMOParty.class, false);
         }
     }

--- a/src/subside/plugins/koth/commands/CommandDatatable.java
+++ b/src/subside/plugins/koth/commands/CommandDatatable.java
@@ -45,7 +45,7 @@ public class CommandDatatable extends AbstractCommand {
     
     public void debug(CommandSender sender, String[] args){
         if(args.length < 2)
-            throw new CommandMessageException(Lang.COMMAND_GLOBAL_USAGE[0] + "/koth datatabe debug (0|1|2) <maxrows> [time] [capturetype] [gamemode] [koth]");
+            throw new CommandMessageException(Lang.COMMAND_GLOBAL_USAGE[0] + "/koth datatable debug (0|1|2) <maxrows> [time] [capturetype] [gamemode] [koth]");
         
         if(args[0].equalsIgnoreCase("2")){
             Utils.sendMessage(sender, true, "Player results returned:");

--- a/src/subside/plugins/koth/commands/CommandDatatable.java
+++ b/src/subside/plugins/koth/commands/CommandDatatable.java
@@ -45,7 +45,7 @@ public class CommandDatatable extends AbstractCommand {
     
     public void debug(CommandSender sender, String[] args){
         if(args.length < 2)
-            throw new CommandMessageException(Lang.COMMAND_GLOBAL_USAGE[0] + "/koth debug (0|1|2) <maxrows> [time] [capturetype] [gamemode] [koth]");
+            throw new CommandMessageException(Lang.COMMAND_GLOBAL_USAGE[0] + "/koth datatabe debug (0|1|2) <maxrows> [time] [capturetype] [gamemode] [koth]");
         
         if(args[0].equalsIgnoreCase("2")){
             Utils.sendMessage(sender, true, "Player results returned:");

--- a/src/subside/plugins/koth/commands/CommandEdit.java
+++ b/src/subside/plugins/koth/commands/CommandEdit.java
@@ -150,7 +150,7 @@ public class CommandEdit extends AbstractCommand {
         Player player = (Player)sender;
         if(args.length > 0){
             if(args[0].equalsIgnoreCase("setpos")){
-                Block block = player.getTargetBlock((HashSet<Byte>)null, 8);
+                Block block = player.getTargetBlock(null, 8);
                 
                 if(block == null){
                     throw new CommandMessageException(Lang.COMMAND_EDITOR_LOOT_SETNOBLOCK);

--- a/src/subside/plugins/koth/commands/CommandEdit.java
+++ b/src/subside/plugins/koth/commands/CommandEdit.java
@@ -1,11 +1,15 @@
 package subside.plugins.koth.commands;
 
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
 import java.util.Arrays;
 import java.util.HashSet;
+import java.util.Set;
 
 import org.bukkit.Location;
 import org.bukkit.block.Block;
 import org.bukkit.command.CommandSender;
+import org.bukkit.entity.LivingEntity;
 import org.bukkit.entity.Player;
 
 import com.sk89q.worldedit.bukkit.WorldEditPlugin;
@@ -142,16 +146,30 @@ public class CommandEdit extends AbstractCommand {
                 new MessageBuilder(Lang.COMMAND_GLOBAL_HELP_INFO).command("/koth edit <koth> area list").commandInfo("shows the area list").build(),
                 new MessageBuilder(Lang.COMMAND_GLOBAL_HELP_INFO).command("/koth edit <koth> area remove <area>").commandInfo("removes an area").build());
     }
-    
-    @SuppressWarnings({
-            "deprecation"
-    })
+
     private void loot(CommandSender sender, String[] args, Koth koth){
         Player player = (Player)sender;
         if(args.length > 0){
             if(args[0].equalsIgnoreCase("setpos")){
-                Block block = player.getTargetBlock(null, 8);
-                
+                Block block;
+                try {
+                    Method method;
+                    try {
+                        method = LivingEntity.class.getDeclaredMethod("getTargetBlock", Set.class, int.class);
+                    } catch(NoSuchMethodException e){
+                        method = LivingEntity.class.getDeclaredMethod("getTargetBlock", HashSet.class, int.class);
+                    }
+                    block = (Block)method.invoke(player, null, 8);
+                } catch(NoSuchMethodException e){
+                    getPlugin().getLogger().severe("Cannot find the getTargetBlock function!");
+                    e.printStackTrace();
+                    return;
+                } catch(IllegalAccessException | InvocationTargetException e){
+                    getPlugin().getLogger().severe("Cannot access the getTargetBlock function!");
+                    e.printStackTrace();
+                    return;
+                }
+
                 if(block == null){
                     throw new CommandMessageException(Lang.COMMAND_EDITOR_LOOT_SETNOBLOCK);
                 }

--- a/src/subside/plugins/koth/commands/CommandHandler.java
+++ b/src/subside/plugins/koth/commands/CommandHandler.java
@@ -45,6 +45,7 @@ public class CommandHandler extends AbstractModule implements CommandExecutor {
         
         if(getPlugin().getDataTable() != null){
             basic.addCommand(new CommandDatatable(basic));
+            basic.addCommand(new CommandTop(basic));
         }
         
         // Control commands

--- a/src/subside/plugins/koth/commands/CommandSchedule.java
+++ b/src/subside/plugins/koth/commands/CommandSchedule.java
@@ -70,13 +70,26 @@ public class CommandSchedule extends AbstractCommand {
     }
 
     private void asMember(CommandSender sender, String[] args) {
+        Day dayFilter = Day.getCurrentDay();
+        boolean showSingleDay = getPlugin().getConfigHandler().getGlobal().isCurrentDayOnly();
+
+        if(args.length > 0){
+            if(args[0].equalsIgnoreCase("today")) {
+                dayFilter = Day.getCurrentDay();
+            } else {
+                dayFilter = Day.getDay(args[0]);
+            }
+            showSingleDay = true;
+        }
+
         List<Schedule> schedules = getPlugin().getScheduleHandler().getSchedules();
         List<String> list = new ArrayList<>();
        
         list.add(" ");
         list.addAll(new MessageBuilder(Lang.COMMAND_SCHEDULE_LIST_CURRENTDATETIME).date(Utils.parseCurrentDate(getPlugin())).buildArray());
         for (Day day : Day.values()) {
-            if(getPlugin().getConfigHandler().getGlobal().isCurrentDayOnly() && day != Day.getCurrentDay())
+            // All filtering, like day arguments and such
+            if(showSingleDay && day != dayFilter)
                 continue;
             
             List<String> subList = new ArrayList<>();
@@ -88,6 +101,9 @@ public class CommandSchedule extends AbstractCommand {
             if (subList.size() > 0) {
                 list.addAll(new MessageBuilder(Lang.COMMAND_SCHEDULE_LIST_DAY).day(day.getDay()).buildArray());
                 list.addAll(subList);
+            } else if(showSingleDay){
+                list.addAll(new MessageBuilder(Lang.COMMAND_SCHEDULE_LIST_DAY).day(day.getDay()).buildArray());
+                list.addAll(new MessageBuilder(Lang.COMMAND_SCHEDULE_LIST_NOENTRYFOUND).day(day.getDay()).buildArray());
             }
         }
         if (schedules.size() < 1) {

--- a/src/subside/plugins/koth/commands/CommandTop.java
+++ b/src/subside/plugins/koth/commands/CommandTop.java
@@ -85,7 +85,7 @@ public class CommandTop extends AbstractCommand {
 
     @Override
     public IPerm getPermission() {
-        return Perm.Admin.EDIT;
+        return Perm.TOP;
     }
 
     @Override

--- a/src/subside/plugins/koth/commands/CommandTop.java
+++ b/src/subside/plugins/koth/commands/CommandTop.java
@@ -1,0 +1,108 @@
+package subside.plugins.koth.commands;
+
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.*;
+
+import org.bukkit.Bukkit;
+import org.bukkit.Location;
+import org.bukkit.OfflinePlayer;
+import org.bukkit.block.Block;
+import org.bukkit.command.CommandSender;
+import org.bukkit.entity.LivingEntity;
+import org.bukkit.entity.Player;
+
+import com.sk89q.worldedit.bukkit.WorldEditPlugin;
+import com.sk89q.worldedit.bukkit.selections.Selection;
+
+import subside.plugins.koth.areas.Area;
+import subside.plugins.koth.areas.Koth;
+import subside.plugins.koth.commands.CommandHandler.CommandCategory;
+import subside.plugins.koth.datatable.DataTable;
+import subside.plugins.koth.exceptions.AreaAlreadyExistException;
+import subside.plugins.koth.exceptions.AreaNotExistException;
+import subside.plugins.koth.exceptions.CommandMessageException;
+import subside.plugins.koth.exceptions.KothNotExistException;
+import subside.plugins.koth.modules.Lang;
+import subside.plugins.koth.utils.IPerm;
+import subside.plugins.koth.utils.MessageBuilder;
+import subside.plugins.koth.utils.Perm;
+import subside.plugins.koth.utils.Utils;
+
+public class CommandTop extends AbstractCommand {
+
+    public CommandTop(CommandCategory category) {
+        super(category);
+    }
+
+    @Override
+    public void run(final CommandSender sender, final String[] args) {
+        if(!getPlugin().getConfigHandler().getDatabase().isEnabled())
+            return;
+
+        Bukkit.getScheduler().runTaskAsynchronously(getPlugin(), () -> {
+            DataTable.SimpleQueryBuilder builder = getPlugin().getDataTable().getSQLBuilder();
+
+            ResultSet result;
+            try {
+                int page = 1;
+
+                if(args.length > 0){
+                    try {
+                        page = Integer.parseInt(args[0]);
+                    } catch(NumberFormatException e){
+                        new MessageBuilder(Lang.COMMAND_TOP_NOTANUMBER).buildAndSend(sender);
+                        return;
+                    }
+                }
+
+                result = builder.limit(10).offset((page - 1) * 10).execute();
+
+                List<String> msgs = new ArrayList<>();
+                msgs.addAll(new MessageBuilder(Lang.COMMAND_TOP_TITLE).buildArray());
+
+                int i = (page - 1) * 10 + 1;
+                while (result.next()) {
+                    msgs.addAll(
+                            new MessageBuilder(Lang.COMMAND_TOP_ENTRY)
+                                    .id(i++)
+                                    .times(""+result.getInt("result"))
+                                    .capper(Bukkit.getOfflinePlayer(UUID.fromString(result.getString("player_uuid"))).getName())
+                                    .buildArray()
+                    );
+                }
+
+                msgs.addAll(new MessageBuilder(Lang.COMMAND_TOP_PAGE).times(""+page).buildArray());
+
+                Utils.sendMsg(sender, msgs);
+            } catch(SQLException e){
+                e.printStackTrace();
+            }
+        });
+    }
+
+    @Override
+    public IPerm getPermission() {
+        return Perm.Admin.EDIT;
+    }
+
+    @Override
+    public String[] getCommands() {
+        return new String[] {
+                "top"
+        };
+    }
+
+    @Override
+    public String getUsage() {
+        return "/koth top [page]";
+    }
+
+    @Override
+    public String getDescription() {
+        return "Shows the top list";
+    }
+
+}

--- a/src/subside/plugins/koth/commands/CommandVersion.java
+++ b/src/subside/plugins/koth/commands/CommandVersion.java
@@ -21,7 +21,10 @@ public class CommandVersion extends AbstractCommand {
         list.add(" ");
         list.addAll(new MessageBuilder("&8========> &2INFO &8<========").buildArray());
         list.addAll(new MessageBuilder("&2Author: &aSubSide").buildArray());
-        list.addAll(new MessageBuilder("&2Version: &a" + getPlugin().getDescription().getVersion()).buildArray());
+
+        String version = "&a" + getPlugin().getDescription().getVersion()
+                + (getPlugin().getVersionChecker().getNewVersion() != null ? " &7(outdated)" : "");
+        list.addAll(new MessageBuilder("&2Version: &a"+ version).buildArray());
         list.addAll(new MessageBuilder("&2Site: &ahttp://bit.ly/1Pyxu2N").buildArray());
         sender.sendMessage(list.toArray(new String[list.size()]));
     }

--- a/src/subside/plugins/koth/gamemodes/KothClassic.java
+++ b/src/subside/plugins/koth/gamemodes/KothClassic.java
@@ -52,7 +52,6 @@ public class KothClassic extends RunningKoth {
         if(getPlugin().getConfigHandler().getKoth().isRemoveChestAtStart()){
             koth.removeLootChest();
         }
-        koth.setLastWinner(null);
         new MessageBuilder(Lang.KOTH_PLAYING_STARTING).maxTime(maxRunTime).time(getTimeObject()).koth(koth).buildAndBroadcast();
     }
     

--- a/src/subside/plugins/koth/modules/ConfigHandler.java
+++ b/src/subside/plugins/koth/modules/ConfigHandler.java
@@ -96,6 +96,7 @@ public class ConfigHandler extends AbstractModule {
 	    private @Getter boolean vanishNoPacket = true;
 	    private @Getter boolean factions = true;
 	    private @Getter boolean kingdoms = true;
+        private @Getter boolean feudalKingdoms = true;
 	    private @Getter boolean gangs = true;
         private @Getter boolean mcMMO = true;
         private @Getter boolean pvpManager = true;
@@ -108,6 +109,7 @@ public class ConfigHandler extends AbstractModule {
             vanishNoPacket = section.getBoolean("vanishnopacket");
             factions = section.getBoolean("factions");
             kingdoms = section.getBoolean("kingdoms");
+            feudalKingdoms = section.getBoolean("feudalkingdoms");
             pvpManager = section.getBoolean("pvpmanager");
             gangs = section.getBoolean("gangs");
             mcMMO = section.getBoolean("mcmmo");

--- a/src/subside/plugins/koth/modules/ConfigHandler.java
+++ b/src/subside/plugins/koth/modules/ConfigHandler.java
@@ -272,8 +272,8 @@ public class ConfigHandler extends AbstractModule {
             private @Getter boolean savePlayerIgnores = true;
 
             public Modules(ConfigurationSection section){
-                saveKothWins = section.getBoolean("save-koth-wins");
-                savePlayerIgnores = section.getBoolean("save-player-ignores");
+                saveKothWins = section.getBoolean("saveKothWins");
+                savePlayerIgnores = section.getBoolean("savePlayerIgnores");
             }
         }
     }

--- a/src/subside/plugins/koth/modules/ConfigHandler.java
+++ b/src/subside/plugins/koth/modules/ConfigHandler.java
@@ -209,6 +209,7 @@ public class ConfigHandler extends AbstractModule {
         private @Getter boolean ffaChestTimeLimit = false;
         private @Getter int broadcastInterval = 30;
         private @Getter int minimumPlayersNeeded = 0;
+        private @Getter boolean startNewOnEnd = false;
         private @Getter String defaultCaptureType = "Player";
         private @Getter List<String> mapRotation = new ArrayList<>();
 
@@ -223,6 +224,7 @@ public class ConfigHandler extends AbstractModule {
             broadcastInterval = section.getInt("broadcast-interval");
             captureCooldown = section.getInt("capture-cooldown");
             minimumPlayersNeeded = section.getInt("minimum-players");
+            startNewOnEnd = section.getBoolean("start-new-on-end");
             defaultCaptureType = section.getString("default-capturetype");
             mapRotation = section.getStringList("map-rotation");
 

--- a/src/subside/plugins/koth/modules/Lang.java
+++ b/src/subside/plugins/koth/modules/Lang.java
@@ -71,7 +71,7 @@ public class Lang extends AbstractModule {
     public static String[] COMMAND_TOP_TITLE = new String[]{ "&8========> &2KoTH top wins &8<========" };
     public static String[] COMMAND_TOP_ENTRY = new String[]{ "&7#%id% - &a%capper% [%times% wins]" };
     public static String[] COMMAND_TOP_PAGE = new String[]{"", "&7Page %times%"};
-    public static String[] COMMAND_TOP_NOTANUMBER = new String[]{ "This is not a number!" };
+    public static String[] COMMAND_TOP_NOTANUMBER = new String[]{ "&cThis is not a number!" };
 
     public static String[] COMMAND_IGNORE_START = new String[]{ "&aChat messages from &2KoTH &aare now ignored." };
     public static String[] COMMAND_IGNORE_STOP = new String[]{ "&aChat messages from &2KoTH &aare now shown." };

--- a/src/subside/plugins/koth/modules/Lang.java
+++ b/src/subside/plugins/koth/modules/Lang.java
@@ -153,6 +153,8 @@ public class Lang extends AbstractModule {
 	public static String[] COMMAND_SCHEDULE_LIST_DAY = new String[]{"&8========> &2%day% &8<========"};
 	public static String[] COMMAND_SCHEDULE_LIST_ENTRY = new String[]{"&a%koth% at %time%"};
 	public static String[] COMMAND_SCHEDULE_LIST_BOTTOM = new String[]{""};
+	public static String[] COMMAND_SCHEDULE_LIST_NOENTRYFOUND = new String[]{ "&aNo entries found!" };
+
 	public static String[] COMMAND_SCHEDULE_ADMIN_LIST_CURRENTDATETIME = new String[]{"&aCurrent date: %date%"};
 	public static String[] COMMAND_SCHEDULE_ADMIN_LIST_DAY = new String[]{"&8========> &2%day% &8<========"};
 	public static String[] COMMAND_SCHEDULE_ADMIN_LIST_ENTRY = new String[]{"&a(#%id%) %koth% at %time% with a capture time of %ct%"};

--- a/src/subside/plugins/koth/modules/Lang.java
+++ b/src/subside/plugins/koth/modules/Lang.java
@@ -39,7 +39,7 @@ public class Lang extends AbstractModule {
     public static String[] KOTH_DAY_FRIDAY = new String[]{ "Friday" };
     public static String[] KOTH_DAY_SATURDAY = new String[]{ "Saturday" };
     public static String[] KOTH_DAY_SUNDAY = new String[]{ "Sunday" };
-    
+
     public static String[] HOOKS_PLACEHOLDERAPI_NOONECAPPING = new String[]{ "No One" };
     public static String[] HOOKS_PLACEHOLDERAPI_TIMETILL = new String[]{ "%hh%:%mm%:%ss%" };
     
@@ -67,6 +67,11 @@ public class Lang extends AbstractModule {
     public static String[] COMMAND_GLOBAL_WESELECT = new String[]{"&aYou need to select an koth with worldedit!"};
     public static String[] COMMAND_GLOBAL_HELP_TITLE = new String[]{"&8========> &2%title% &8<========"};
     public static String[] COMMAND_GLOBAL_HELP_INFO = new String[]{"&a%command% &7%command_info%"};
+
+    public static String[] COMMAND_TOP_TITLE = new String[]{ "&8========> &2KoTH top wins &8<========" };
+    public static String[] COMMAND_TOP_ENTRY = new String[]{ "&7#%id% - &a%capper% [%times% wins]" };
+    public static String[] COMMAND_TOP_PAGE = new String[]{"", "&7Page %times%"};
+    public static String[] COMMAND_TOP_NOTANUMBER = new String[]{ "This is not a number!" };
 
     public static String[] COMMAND_IGNORE_START = new String[]{ "&aChat messages from &2KoTH &aare now ignored." };
     public static String[] COMMAND_IGNORE_STOP = new String[]{ "&aChat messages from &2KoTH &aare now shown." };

--- a/src/subside/plugins/koth/modules/VersionChecker.java
+++ b/src/subside/plugins/koth/modules/VersionChecker.java
@@ -1,0 +1,91 @@
+package subside.plugins.koth.modules;
+
+import lombok.Getter;
+import org.bukkit.Bukkit;
+import org.bukkit.ChatColor;
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.HandlerList;
+import org.bukkit.event.Listener;
+import org.bukkit.event.player.PlayerJoinEvent;
+import subside.plugins.koth.KothPlugin;
+import subside.plugins.koth.utils.Perm;
+
+import java.io.BufferedReader;
+import java.io.InputStreamReader;
+import java.net.URL;
+import java.net.URLConnection;
+
+public class VersionChecker extends AbstractModule implements Listener {
+
+    private @Getter String newVersion = null;
+
+    public VersionChecker(KothPlugin plugin) {
+        super(plugin);
+    }
+
+    @Override
+    public void onEnable() {
+        // Register the events
+        plugin.getServer().getPluginManager().registerEvents(this, plugin);
+        Bukkit.getScheduler().runTaskAsynchronously(getPlugin(), () -> checkUpdate());
+    }
+
+    @Override
+    public void onDisable() {
+        // Remove all previous event handlers
+        HandlerList.unregisterAll(this);
+    }
+
+    private void checkUpdate() {
+        try {
+            // Open a connection to our version checker URL
+            URL url = new URL("https://api.spigotmc.org/legacy/update.php?resource=7689");
+            URLConnection conn = url.openConnection();
+            conn.setRequestProperty("User-Agent", "Mozilla/1.0");
+            conn.setConnectTimeout(1000);
+            conn.connect();
+            BufferedReader in = new BufferedReader(new InputStreamReader(conn.getInputStream()));
+            String inputLine = in.readLine();
+            in.close();
+
+            // If our version is the same as the latest version online, we ignore this
+            if(getPlugin().getDescription().getVersion().equals(inputLine)) {
+                return;
+            }
+
+            // Otherwise we update newVersion to what we read online
+            newVersion = inputLine;
+
+            // Then we broadcast it to both the console as every player that has the admin.admin perm.
+            String[] msgs = {
+                    ChatColor.translateAlternateColorCodes('&', "&aAn update for &2KoTH (KoTH 1.5.1) &ais available at"),
+                    ChatColor.translateAlternateColorCodes('&', "&bhttps://www.spigotmc.org/resources/KoTH.7689/")
+            };
+
+            getPlugin().getLogger().info(msgs[0]);
+            getPlugin().getLogger().info(msgs[1]);
+
+            for(Player player : Bukkit.getOnlinePlayers()){
+                if(Perm.Admin.ADMIN.has(player)){
+                    player.sendMessage(msgs);
+                }
+            }
+
+        } catch (Exception e) {
+            this.getPlugin().getLogger().info("Couldn't check for updates");
+        }
+    }
+
+    @EventHandler
+    public void onPlayerJoin(PlayerJoinEvent event){
+        // We also want the message to pop up when a player that has the admin.admin perm joins.
+        if(newVersion != null && Perm.Admin.ADMIN.has(event.getPlayer())){
+            String[] msgs = {
+                    ChatColor.translateAlternateColorCodes('&', "&aAn update for &2KoTH (KoTH 1.5.1) &ais available at"),
+                    ChatColor.translateAlternateColorCodes('&', "&bhttps://www.spigotmc.org/resources/KoTH.7689/")
+            };
+            event.getPlayer().sendMessage(msgs);
+        }
+    }
+}

--- a/src/subside/plugins/koth/modules/VersionChecker.java
+++ b/src/subside/plugins/koth/modules/VersionChecker.java
@@ -57,21 +57,6 @@ public class VersionChecker extends AbstractModule implements Listener {
             // Otherwise we update newVersion to what we read online
             newVersion = inputLine;
 
-            // Then we broadcast it to both the console as every player that has the admin.admin perm.
-            String[] msgs = {
-                    ChatColor.translateAlternateColorCodes('&', "&aAn update for &2KoTH (KoTH 1.5.1) &ais available at"),
-                    ChatColor.translateAlternateColorCodes('&', "&bhttps://www.spigotmc.org/resources/KoTH.7689/")
-            };
-
-            getPlugin().getLogger().info(msgs[0]);
-            getPlugin().getLogger().info(msgs[1]);
-
-            for(Player player : Bukkit.getOnlinePlayers()){
-                if(Perm.Admin.ADMIN.has(player)){
-                    player.sendMessage(msgs);
-                }
-            }
-
         } catch (Exception e) {
             this.getPlugin().getLogger().info("Couldn't check for updates");
         }
@@ -82,8 +67,8 @@ public class VersionChecker extends AbstractModule implements Listener {
         // We also want the message to pop up when a player that has the admin.admin perm joins.
         if(newVersion != null && Perm.Admin.ADMIN.has(event.getPlayer())){
             String[] msgs = {
-                    ChatColor.translateAlternateColorCodes('&', "&aAn update for &2KoTH (KoTH 1.5.1) &ais available at"),
-                    ChatColor.translateAlternateColorCodes('&', "&bhttps://www.spigotmc.org/resources/KoTH.7689/")
+                    ChatColor.translateAlternateColorCodes('&', "&aAn update for &2KoTH (KoTH "+newVersion+") &ais available at:"),
+                    ChatColor.translateAlternateColorCodes('&', "&ahttps://www.spigotmc.org/resources/KoTH.7689/")
             };
             event.getPlayer().sendMessage(msgs);
         }

--- a/src/subside/plugins/koth/utils/MessageBuilder.java
+++ b/src/subside/plugins/koth/utils/MessageBuilder.java
@@ -164,6 +164,11 @@ public class MessageBuilder {
         return this;
     }
 
+    public MessageBuilder times(String times){
+        message.replaceAll("%times%", times);
+        return this;
+    }
+
     public MessageBuilder captureTime(int captureTime) {
         message.replaceAll("%ct%", "" + captureTime);
         return this;

--- a/src/subside/plugins/koth/utils/Perm.java
+++ b/src/subside/plugins/koth/utils/Perm.java
@@ -3,7 +3,7 @@ package subside.plugins.koth.utils;
 import org.bukkit.command.CommandSender;
 
 public enum Perm implements IPerm {
-	LIST("list"), LOOT("loot"), NEXT("next"), SCHEDULE("schedule"), VERSION("version"), HELP("help"), IGNORE("ignore");
+	LIST("list"), LOOT("loot"), NEXT("next"), SCHEDULE("schedule"), VERSION("version"), HELP("help"), IGNORE("ignore"), TOP("top");
 	
 	private String perm;
 	


### PR DESCRIPTION
Changelog:
- Fixed 1.12.2 getTargetBlock compatibility error
- Added: Feudal Kingdoms support
- Added: Start-new-on-end config option that uses the map rotation to start a new koth when the last one ends (needs to be kick-started with a /koth start and can be stopped with /koth stop)
- Fixed: CappingGroup not being registered.
- Fixed: Datatable not working because of config issues
- Added: A basic /koth top command