### PR TITLE
Fixed PAPI Support

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -32,6 +32,14 @@
         </repository>
     </repositories>
     <dependencies>
+        <!-- Lombok -->
+        <dependency>
+            <groupId>org.projectlombok</groupId>
+            <artifactId>lombok</artifactId>
+            <version>1.18.16</version>
+            <scope>provided</scope>
+        </dependency>
+
         <dependency>
             <groupId>org.spigotmc</groupId>
             <artifactId>spigot-api</artifactId>
@@ -46,7 +54,7 @@
         <dependency>
          <groupId>me.clip</groupId>
           <artifactId>placeholderapi</artifactId>
-          <version>2.0.8</version>
+          <version>2.10.9</version>
          <scope>provided</scope>
         </dependency>
     </dependencies>

--- a/src/subside/plugins/koth/hooks/HookManager.java
+++ b/src/subside/plugins/koth/hooks/HookManager.java
@@ -29,7 +29,7 @@ public class HookManager extends AbstractModule {
         registerHook(new EssentialsVanishHook(this));
         
         if(Bukkit.getServer().getPluginManager().isPluginEnabled("PlaceholderAPI")){
-            new PlaceholderAPIHook(plugin).hook();
+            new PlaceholderAPIHook(plugin).register();
         }
     }
     

--- a/src/subside/plugins/koth/hooks/PlaceholderAPIHook.java
+++ b/src/subside/plugins/koth/hooks/PlaceholderAPIHook.java
@@ -1,8 +1,9 @@
 package subside.plugins.koth.hooks;
 
+import me.clip.placeholderapi.expansion.PlaceholderExpansion;
 import org.bukkit.entity.Player;
 
-import me.clip.placeholderapi.external.EZPlaceholderHook;
+import org.jetbrains.annotations.NotNull;
 import subside.plugins.koth.KothPlugin;
 import subside.plugins.koth.areas.Koth;
 import subside.plugins.koth.gamemodes.RunningKoth;
@@ -13,13 +14,36 @@ import subside.plugins.koth.scheduler.Schedule;
 /**
 * Made in collaboration with F64_Rx <3
 */
-public class PlaceholderAPIHook extends EZPlaceholderHook {
+public class PlaceholderAPIHook extends PlaceholderExpansion {
     KothPlugin plugin;
     
     public PlaceholderAPIHook(KothPlugin plugin) {
-        super(plugin, "koth");
-        
         this.plugin = plugin;
+    }
+
+    @Override
+    public @NotNull String getIdentifier() {
+        return "koth";
+    }
+
+    @Override
+    public @NotNull String getAuthor() {
+        return String.join(", ", plugin.getDescription().getAuthors());
+    }
+
+    @Override
+    public @NotNull String getVersion() {
+        return plugin.getDescription().getVersion();
+    }
+
+    @Override
+    public boolean canRegister() {
+        return true;
+    }
+
+    @Override
+    public boolean persist() {
+        return true;
     }
 
     @Override
@@ -27,8 +51,8 @@ public class PlaceholderAPIHook extends EZPlaceholderHook {
         if (player == null) {
             return "";
         }
-        
-        
+
+
         // Loop over all all live KoTH's
         if(identifier.startsWith("live_")){
             for(Koth koth : plugin.getKothHandler().getAvailableKoths()){
@@ -36,61 +60,61 @@ public class PlaceholderAPIHook extends EZPlaceholderHook {
                 if(replacer != null) return replacer;
             }
         }
-        
+
         // Loop over all schedules.
         if(identifier.startsWith("next_")){
             if(plugin.getScheduleHandler().getNextEvent() != null){
                 Schedule schedule = plugin.getScheduleHandler().getNextEvent();
                 if(schedule == null) return "";
-                
+
                 if(schedule.getKoth().startsWith("$")){
                     String scheduleReplacer = replaceSchedulingHolders(identifier, "next_", schedule);
                     if(scheduleReplacer != null) return scheduleReplacer;
-                    
+
                     return "???";
                 }
-                
+
                 Koth koth = plugin.getKothHandler().getKoth(schedule.getKoth());
                 if(koth == null) return "";
-                
+
                 String replacer = replaceHolders(identifier, "next_", koth, player);
                 if(replacer != null) return replacer;
             }
         }
-        
+
         // Check if  there is a running KoTH
         if (plugin.getKothHandler().getRunningKoth() == null) return "";
-        
+
         RunningKoth rKoth = plugin.getKothHandler().getRunningKoth();
         if (rKoth == null) return "";
-        
+
         String replacer = replaceHolders(identifier, "", rKoth.getKoth(), player);
         if(replacer != null) return replacer;
-        
+
         return "";
     }
-    
+
     public String replaceHolders(String identifier, String prefix, Koth koth, Player player){
-        
+
         if (identifier.equals(prefix+"name")) return koth.getName();
         if (identifier.equals(prefix+"x")) return koth.getMiddle().getBlockX() + "";
         if (identifier.equals(prefix+"y")) return koth.getMiddle().getBlockY() + "";
         if (identifier.equals(prefix+"z")) return koth.getMiddle().getBlockZ() + "";
         if (identifier.equals(prefix+"world")) return koth.getMiddle().getWorld().getName();
-        
+
         if (identifier.equals(prefix+"player_inarea")) return koth.isInArea(player)?"True":"False";
-        
+
 
         if(identifier.equals(prefix+"nextevent")) return TimeObject.getTimeTillNextEvent(plugin, koth);
-                
+
         if(identifier.equals(prefix+"lastwinner")){
             if(koth.getLastWinner() == null) return "";
             return koth.getLastWinner().getName();
         }
-        
+
         if(identifier.equals(prefix+"isrunning")) return koth.isRunning()?"True":"False";
 
-        
+
         if (identifier.equals(prefix+"loot_x")) {
             if (koth.getLootPos() == null) return "No Loot Set";
             return "" + koth.getLootPos().getBlockX();
@@ -107,23 +131,23 @@ public class PlaceholderAPIHook extends EZPlaceholderHook {
             if (koth.getLootPos() == null) return "No Loot Set";
             return "" + koth.getLootPos().getWorld().getName();
         }
-        
+
         RunningKoth rKoth = koth.getRunningKoth();
         if (rKoth != null){
             return replaceRunningKothHolders(identifier, prefix, rKoth);
         }
-        
-        
+
+
         return null;
     }
-    
+
     public String replaceSchedulingHolders(String identifier, String prefix, Schedule schedule){
         if (identifier.equals(prefix+"nextevent")) return TimeObject.getTimeTillNextEvent(schedule);
         if (identifier.equals(prefix+"name")) return schedule.getKoth();
         if (identifier.equals(prefix+"time")) return schedule.getTime();
         return null;
     }
-    
+
     public String replaceRunningKothHolders(String identifier, String prefix, RunningKoth rKoth){
 
         if (identifier.equals(prefix+"time_secondsleft")) return "" + rKoth.getTimeObject().getSecondsLeft();
@@ -138,19 +162,18 @@ public class PlaceholderAPIHook extends EZPlaceholderHook {
         if (identifier.equals(prefix+"time_lengthinseconds")) return "" + rKoth.getTimeObject().getLengthInSeconds();
         if (identifier.equals(prefix+"time_percentagecapped")) return "" + rKoth.getTimeObject().getPercentageCapped();
         if (identifier.equals(prefix+"time_percentageleft")) return "" + rKoth.getTimeObject().getPercentageLeft();
-        
+
         if (identifier.equals(prefix+"currentcapper")) {
             if (rKoth.getCapper() == null) return Lang.HOOKS_PLACEHOLDERAPI_NOONECAPPING[0];
             return rKoth.getCapper().getName();
         }
-        
-        
+
+
         if (identifier.equals(prefix+"loot_name")) {
             if (rKoth.getLootChest() == null) return "No Loot Set";
             return rKoth.getLootChest();
         }
-        
+
         return null;
     }
-
 }

--- a/src/subside/plugins/koth/hooks/PlaceholderAPIHook.java
+++ b/src/subside/plugins/koth/hooks/PlaceholderAPIHook.java
@@ -47,7 +47,7 @@ public class PlaceholderAPIHook extends PlaceholderExpansion {
     }
 
     @Override
-    public String onPlaceholderRequest(Player player, String identifier) {
+    public String onPlaceholderRequest(Player player, @NotNull String identifier) {
         if (player == null) {
             return "";
         }


### PR DESCRIPTION
PlaceholderAPI recently removed EZPlaceholderHook which made the plugin break on server that used the newer version of PAPI. This just fixes that.